### PR TITLE
Fix tests on windows

### DIFF
--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -75,7 +75,6 @@ end
 end
 @static if !_AVOID_PLATFORM_SPECIFIC_LLVM_CODE
     @inline function _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val)
-        println(ptr - len)
         ScanByte.memchr(ptr, len, valbs)
     end
 end
@@ -284,11 +283,14 @@ function _find_newlines_generic!(l::Lexer{E,OQ,CQ}, buf, out, curr_pos::Int=firs
         end
     end
 
-    ptr += offset
     ended_on_escape = false
+    ptr0 = ptr += offset
+    len = bytes_to_search
+    base_ptr = pointer(buf)
     @inbounds while bytes_to_search > 0
         # ScanByte seems to sometimes return an UInt instead of an Int in
         # some fallback implementations.
+        @assert (((bytes_to_search + ptr) == (ptr0 + len)) && (bytes_to_search + ptr == base_ptr + end_pos)) "$l $(repr(String(buf[:]))) $(Int(bytes_to_search + ptr)) $(Int(ptr0 + len)) $(Int(base_ptr + end_pos))"
         pos_to_check = Base.bitcast(Int, something(_internal_memchr(ptr, Core.bitcast(UInt, bytes_to_search), structural_characters), 0))
         pos_to_check == 0 && break
 

--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -283,14 +283,11 @@ function _find_newlines_generic!(l::Lexer{E,OQ,CQ}, buf, out, curr_pos::Int=firs
         end
     end
 
+    ptr += offset
     ended_on_escape = false
-    ptr0 = ptr += offset
-    len = bytes_to_search
-    base_ptr = pointer(buf)
     @inbounds while bytes_to_search > 0
         # ScanByte seems to sometimes return an UInt instead of an Int in
         # some fallback implementations.
-        @assert (((bytes_to_search + ptr) == (ptr0 + len)) && (bytes_to_search + ptr == base_ptr + end_pos)) "$l $(repr(String(buf[:]))) $(Int(bytes_to_search + ptr)) $(Int(ptr0 + len)) $(Int(base_ptr + end_pos))"
         pos_to_check = Base.bitcast(Int, something(_internal_memchr(ptr, Core.bitcast(UInt, bytes_to_search), structural_characters), 0))
         pos_to_check == 0 && break
 

--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -75,7 +75,7 @@ end
 end
 @static if !_AVOID_PLATFORM_SPECIFIC_LLVM_CODE
     @inline function _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val)
-        ScanByte.memchr(ptr, len, valbs)
+        ScanByte.memchr(ScanByte.SizedMemory(Ptr{UInt8}(ptr), len), valbs)
     end
 end
 @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, byte::UInt8) = ScanByte.memchr(ptr, len, byte)

--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -75,10 +75,10 @@ end
 end
 @static if !_AVOID_PLATFORM_SPECIFIC_LLVM_CODE
     @inline function _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val)
-        ScanByte.memchr(ptr, len, valbs)
+        ScanByte.memchr(ScanByte.SizedMemory(Ptr{UInt8}(ptr), len), valbs)
     end
 end
-@inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, byte::UInt8) = ScanByte.memchr(ptr, len, byte)
+@inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, byte::UInt8) = ScanByte.memchr(ScanByte.SizedMemory(Ptr{UInt8}(ptr), len), byte)
 
 # Rules for Lexer{Q,Q,Q} when there is ambiguity between quotechar and escapechar:
 # we use `prev_escaped` and `prev_in_string` to disambiguate the 4 cases:

--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -68,11 +68,12 @@ let # Feature detection -- copied from ScanByte.jl
     end
 end
 
-if _AVOID_PLATFORM_SPECIFIC_LLVM_CODE
+@static if _AVOID_PLATFORM_SPECIFIC_LLVM_CODE
     # The first argument is used to dispatch on a detected CPU feature set,
     # in this case we want to use the generic fallback, so we provide "nothing".
     @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val) = ScanByte._memchr(nothing, ScanByte.SizedMemory(Ptr{UInt8}(ptr), len), valbs)
-else
+end
+@static if !_AVOID_PLATFORM_SPECIFIC_LLVM_CODE
     @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val) = ScanByte.memchr(ptr, len, valbs)
 end
 @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, byte::UInt8) = ScanByte.memchr(ptr, len, byte)

--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -75,7 +75,7 @@ end
 end
 @static if !_AVOID_PLATFORM_SPECIFIC_LLVM_CODE
     @inline function _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val)
-        ScanByte.memchr(ScanByte.SizedMemory(Ptr{UInt8}(ptr), len), valbs)
+        ScanByte.memchr(ptr, len, valbs)
     end
 end
 @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, byte::UInt8) = ScanByte.memchr(ptr, len, byte)

--- a/src/NewlineLexers.jl
+++ b/src/NewlineLexers.jl
@@ -74,7 +74,10 @@ end
     @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val) = ScanByte._memchr(nothing, ScanByte.SizedMemory(Ptr{UInt8}(ptr), len), valbs)
 end
 @static if !_AVOID_PLATFORM_SPECIFIC_LLVM_CODE
-    @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val) = ScanByte.memchr(ptr, len, valbs)
+    @inline function _internal_memchr(ptr::Ptr{UInt8}, len::UInt, valbs::Val)
+        println(ptr - len)
+        ScanByte.memchr(ptr, len, valbs)
+    end
 end
 @inline _internal_memchr(ptr::Ptr{UInt8}, len::UInt, byte::UInt8) = ScanByte.memchr(ptr, len, byte)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ function setup_for_kernel(l, s; prev_escaped=UInt(0), prev_in_string=UInt(0))
     return newlines
 end
 function generic_lexer_setup(l, buf; prev_escaped=UInt(0), prev_in_string=UInt(0), first=firstindex(buf), last=lastindex(buf))
-    # @info "$(repr(String(buf[:])))"
+    @info "$(repr(String(buf[:])))"
     eols = Int32[]
     l.prev_escaped = prev_escaped
     l.prev_in_string = prev_in_string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ function find_newlines_setup(l, buf; prev_escaped=UInt(0), prev_in_string=UInt(0
     l.prev_escaped = prev_escaped
     l.prev_in_string = prev_in_string
     bytes = collect(codeunits(buf))
-    GC.@preserve bytes NewlineLexers.find_newlines!(l, bytes, eols, first, last)
+    GC.@preserve bytes buf NewlineLexers.find_newlines!(l, bytes, eols, first, last)
     return eols
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,6 @@ function setup_for_kernel(l, s; prev_escaped=UInt(0), prev_in_string=UInt(0))
     return newlines
 end
 function generic_lexer_setup(l, buf; prev_escaped=UInt(0), prev_in_string=UInt(0), first=firstindex(buf), last=lastindex(buf))
-    # @info "$(repr(String(buf[:])))"
     eols = Int32[]
     l.prev_escaped = prev_escaped
     l.prev_in_string = prev_in_string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ function setup_for_kernel(l, s; prev_escaped=UInt(0), prev_in_string=UInt(0))
     return newlines
 end
 function generic_lexer_setup(l, buf; prev_escaped=UInt(0), prev_in_string=UInt(0), first=firstindex(buf), last=lastindex(buf))
-    @info "$(repr(String(buf[:])))"
+    # @info "$(repr(String(buf[:])))"
     eols = Int32[]
     l.prev_escaped = prev_escaped
     l.prev_in_string = prev_in_string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ function setup_for_kernel(l, s; prev_escaped=UInt(0), prev_in_string=UInt(0))
     return newlines
 end
 function generic_lexer_setup(l, buf; prev_escaped=UInt(0), prev_in_string=UInt(0), first=firstindex(buf), last=lastindex(buf))
+    @info "$(repr(String(buf[:])))"
     eols = Int32[]
     l.prev_escaped = prev_escaped
     l.prev_in_string = prev_in_string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,10 +17,10 @@ function setup_for_kernel(l, s; prev_escaped=UInt(0), prev_in_string=UInt(0))
     bytes = collect(codeunits(s))
     newlines = NewlineLexers._find_newlines_kernel!(l, vec64(s))
     eols = Int32[]
-    GC.@preserve bytes NewlineLexers.find_newlines!(l_copy1, bytes, eols)
+    GC.@preserve bytes s NewlineLexers.find_newlines!(l_copy1, bytes, eols)
     @test eols == findall(>(0), digits(newlines, base=2))
     empty!(eols)
-    GC.@preserve bytes NewlineLexers._find_newlines_generic!(l_copy2, bytes, eols)
+    GC.@preserve bytes s NewlineLexers._find_newlines_generic!(l_copy2, bytes, eols)
     @test eols == findall(>(0), digits(newlines, base=2))
     @test l_copy2.prev_escaped == l.prev_escaped
     @test l_copy2.prev_in_string == l.prev_in_string
@@ -33,9 +33,9 @@ function generic_lexer_setup(l, buf; prev_escaped=UInt(0), prev_in_string=UInt(0
     l.prev_in_string = prev_in_string
     l_copy1 = deepcopy(l)
     bytes = collect(codeunits(buf))
-    GC.@preserve bytes NewlineLexers._find_newlines_generic!(l, bytes, eols, first, last)
+    GC.@preserve bytes buf NewlineLexers._find_newlines_generic!(l, bytes, eols, first, last)
     _eols = Int32[]
-    GC.@preserve bytes NewlineLexers.find_newlines!(l_copy1, bytes, _eols, first, last)
+    GC.@preserve bytes buf NewlineLexers.find_newlines!(l_copy1, bytes, _eols, first, last)
     @test _eols == eols
     return eols
 end


### PR DESCRIPTION
I noticed that on [windows CI using Julia 1](https://github.com/JuliaData/NewlineLexers.jl/actions/runs/5255600860/jobs/9542492855) (1.9.1) we we're getting repeatable `Exception: EXCEPTION_ACCESS_VIOLATION at 0x1937a4a0410 -- unsafe_load at .\pointer.jl:111 [inlined]`. The problem went away when I started logging the test input strings which lead me to an idea that they were missing some GC roots, so added the input strings to GC preserve and now the problem no longer occurs. The problem also occurred in the branch that uses ScanByte, which uses pointers instead of touching the byte array directly.

I did spend a lot of time setting up asserts but I think there was no issue in the program logic.